### PR TITLE
Fixed adding of tasks in week view

### DIFF
--- a/src/main/java/data/TaskManager.java
+++ b/src/main/java/data/TaskManager.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Scanner;
 
+import static data.TaskManagerException.NOT_CURRENT_WEEK_MESSAGE;
 import static data.TaskManagerException.checkIfDateHasTasks;
 import static data.TaskManagerException.checkIfDateInCurrentWeek;
 import static data.TaskManagerException.checkIfDateInCurrentMonth;
@@ -361,8 +362,25 @@ public class TaskManager {
             checkIfDateInCurrentMonth(date);
 
         } else {
-            LocalDate startOfMonthForWeekView = weekView.getStartOfMonth();
-            date = startOfMonthForWeekView.plusDays(dayInt - 1);
+            LocalDate startOfWeek = weekView.getStartOfWeek();
+            LocalDate endOfWeek = startOfWeek.plusDays(6);
+            LocalDate startOfMonth = startOfWeek.withDayOfMonth(1);
+            LocalDate possibleDate = startOfMonth.plusDays(dayInt - 1);
+            
+            boolean isBeforeStartOfWeek = possibleDate.isBefore(startOfWeek);
+            boolean isNotInSameMonth = possibleDate.getMonth() != startOfWeek.getMonth();
+            boolean dayIntRefersToNextMonth = isBeforeStartOfWeek || isNotInSameMonth;
+
+            if (dayIntRefersToNextMonth) {
+                LocalDate startOfNextMonth = startOfMonth.plusMonths(1).withDayOfMonth(dayInt);
+                if (startOfNextMonth.isAfter(endOfWeek)) {
+                    throw new TaskManagerException(NOT_CURRENT_WEEK_MESSAGE);
+                }
+                date = startOfNextMonth;
+            } else {
+                date = possibleDate;
+            }
+
             checkIfDateInCurrentWeek(date, weekView);
         }
         return date;

--- a/src/main/java/data/TaskManager.java
+++ b/src/main/java/data/TaskManager.java
@@ -361,7 +361,8 @@ public class TaskManager {
             checkIfDateInCurrentMonth(date);
 
         } else {
-            date = weekView.getStartOfWeek().plusDays(dayInt - 1);
+            LocalDate startOfMonthForWeekView = weekView.getStartOfMonth();
+            date = startOfMonthForWeekView.plusDays(dayInt - 1);
             checkIfDateInCurrentWeek(date, weekView);
         }
         return date;

--- a/src/main/java/time/MonthView.java
+++ b/src/main/java/time/MonthView.java
@@ -103,7 +103,7 @@ public class MonthView extends View {
         startOfView = startOfView.minusMonths(1);
     }
 
-    public LocalDate getStartOfMonth() {
-        return startOfView.withDayOfMonth(1);
-    }
+    // public LocalDate getStartOfMonth() {
+    //     return startOfView.withDayOfMonth(1);
+    // }
 }

--- a/src/main/java/time/View.java
+++ b/src/main/java/time/View.java
@@ -22,4 +22,8 @@ public abstract class View {
     public LocalDate getStartOfView() {
         return startOfView;
     }
+
+    public LocalDate getStartOfMonth() {
+        return startOfView.withDayOfMonth(1);
+    }
 }

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -5,7 +5,7 @@ add,4,T,Organize desk
 add,5,T,Call grandma
 add,6,T,Workout
 add,7,T,Research new project
-add,1,T,Pay bills
+add,31,T,Pay bills
 add,2,T,Buy groceries
 add,2,T,Prepare presentation
 add,3,E,Lunch with team


### PR DESCRIPTION
Fixed it such that user enters the date number in the month rather than the day in the week, to be consistent with the month view.

Also fixed a bug about this:

It runs into an issue when the first day is 31 march, then the subsequent days of the week are in april. When a command like 'add,5,T,make cake' is entered, it attempts to add the task to 5 march instead of 5 april. 